### PR TITLE
Minor cosmetic changes + Ally help

### DIFF
--- a/383a6ac2-6e52-40a5-980f-fade09e4908b/scripts/actions.py
+++ b/383a6ac2-6e52-40a5-980f-fade09e4908b/scripts/actions.py
@@ -112,7 +112,7 @@ def play(card, x = 0, y = 0):
     card.moveToTable(cardPlayed_x_offset, cardPlayed_y_offset)
     notify("{} plays {} from their {}.".format(me, card, src.name))
     # When playing allies, automatically start at 3 stages
-    if card.Type.find("Ally") != -1:
+    if "Ally" in card.Type:
         card.markers[CounterMarker] = 3
 
 def mulligan(group):

--- a/383a6ac2-6e52-40a5-980f-fade09e4908b/scripts/actions.py
+++ b/383a6ac2-6e52-40a5-980f-fade09e4908b/scripts/actions.py
@@ -111,6 +111,9 @@ def play(card, x = 0, y = 0):
         cardPlayed_y_offset = GuestPlayerCardPlayed_y_Offset
     card.moveToTable(cardPlayed_x_offset, cardPlayed_y_offset)
     notify("{} plays {} from their {}.".format(me, card, src.name))
+    # When playing allies, automatically start at 3 stages
+    if card.Type.find("Ally") != -1:
+        card.markers[CounterMarker] = 3
 
 def mulligan(group):
     mute()

--- a/383a6ac2-6e52-40a5-980f-fade09e4908b/scripts/engine.py
+++ b/383a6ac2-6e52-40a5-980f-fade09e4908b/scripts/engine.py
@@ -21,6 +21,7 @@ import re
 def gameSetup():
     faceUpAll()
     me.piles["Life Deck"].shuffle()
+    notify("{} shuffles their Life Deck.", me)
     for c in table:
         if c.controller == me and c.properties["Card Level"] is not "":
             c.markers[CounterMarker] = 5
@@ -145,9 +146,9 @@ def manageRejuvenatePhase():
 def rejuvenate(count = 1, silent = False):
     for card in me.piles["Discard Pile"].top(count):
         mute()
-        card.moveToBottom(me.piles["Life Deck"])
         if silent == False:
             notify("{} Rejuvenates {}.".format(me, card))
+        card.moveToBottom(me.piles["Life Deck"])
 
 def lookupAttackTable(group, x = 0, y = 0):
     mute()


### PR DESCRIPTION
### Logging updates
- Fixes a minor bug where the Rejuvenation notification is performed after the card is Rejuvenated, which means it is identified as "Card" in the notification since it's already moved to the Life Deck
- Adds a notification that decks were shuffled during game setup automation.

### Ally update
- If a card the contains "Ally" in its "Card Type" is _played_ (e.g. by double-click from hand or right-click>Play) then it starts with 3 counters. Minor QoL update.